### PR TITLE
rss: handle valid empty fields

### DIFF
--- a/rss/rss.go
+++ b/rss/rss.go
@@ -42,17 +42,22 @@ func (ch *Channel) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	t, err := time.Parse(time.RFC1123Z, aux.PubDate)
-	if err != nil {
-		return err
-	}
-	ch.PubDate = t
 
-	t, err = time.Parse(time.RFC1123Z, aux.LastBuildDate)
-	if err != nil {
-		return err
+	if aux.PubDate != "" {
+		t, err := time.Parse(time.RFC1123Z, aux.PubDate)
+		if err != nil {
+			return err
+		}
+		ch.PubDate = t
 	}
-	ch.LastBuildDate = t
+	if aux.LastBuildDate != "" {
+		t, err := time.Parse(time.RFC1123Z, aux.LastBuildDate)
+		if err != nil {
+			return err
+		}
+		ch.LastBuildDate = t
+	}
+
 	return nil
 }
 
@@ -92,11 +97,13 @@ func (it *Item) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	t, err := time.Parse(time.RFC1123Z, aux.PubDate)
-	if err != nil {
-		return err
+	if aux.PubDate != "" {
+		t, err := time.Parse(time.RFC1123Z, aux.PubDate)
+		if err != nil {
+			return err
+		}
+		it.PubDate = t
 	}
-	it.PubDate = t
 	return nil
 }
 

--- a/rss/rss_test.go
+++ b/rss/rss_test.go
@@ -50,3 +50,14 @@ func TestDecode(t *testing.T) {
 		t.Errorf("Entry.Link: expected %q, got %q", "https://risky.biz/RBNEWS410/", item.Link)
 	}
 }
+
+func TestEmpty(t *testing.T) {
+	f, err := os.Open("testdata/empty.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := Decode(f); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/rss/testdata/empty.xml
+++ b/rss/testdata/empty.xml
@@ -1,0 +1,10 @@
+<rss version="2.0">
+	<channel>
+		<title></title>
+		<link>proto://</link>
+		<description></description>
+		<item>
+			<title></title>
+		</item>
+	</channel>
+</rss>


### PR DESCRIPTION
Ran into a problem when trying to parse the feed at https://hnrss.org/frontpage. That feed's channel has no pubdate element set; UnmarshalXML errors on timestamp parsing with as it gets an empty string. Reading the spec I found very few fields are actually required. Funnily enough testdata/empty.xml is a valid RSS feed - I even verified using the official RSS validator at
https://www.rssboard.org/rss-validator !