### PR TITLE
rss: handle more timestamp variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![godoc](https://pkg.go.dev/static/frontend/badge/badge.svg)](https://pkg.go.dev/github.com/StreatCodes/rss)
+
 ## RSS
 
 Search RSS feeds and collate a feed.

--- a/internal/db/channels.go
+++ b/internal/db/channels.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/streatCodes/rss/rss"
 	bolt "go.etcd.io/bbolt"
@@ -27,11 +28,16 @@ func (db *DB) SaveChannel(url string, channel *rss.Channel) error {
 	return err
 }
 
+var ErrNotExist = errors.New("channel does not exist")
+
 func (db *DB) GetChannel(url string) (*rss.Channel, error) {
 	var channelBytes []byte
 	err := db.raw.View(func(tx *bolt.Tx) error {
 		if bucket := tx.Bucket(channelsBucket); bucket != nil {
 			channelBytes = bucket.Get([]byte(url))
+		}
+		if len(channelBytes) == 0 {
+			return ErrNotExist
 		}
 		return nil
 	})

--- a/internal/templates/error.tmpl
+++ b/internal/templates/error.tmpl
@@ -1,0 +1,8 @@
+{{ define "error" }}
+{{ template "header" }}
+<main>
+<h2>Error</h2>
+<p>{{ . }}</p>
+</main>
+{{ template "footer" }}
+{{ end }}

--- a/rss/rss.go
+++ b/rss/rss.go
@@ -2,6 +2,7 @@ package rss
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io"
 	"time"
 )
@@ -44,16 +45,16 @@ func (ch *Channel) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}
 
 	if aux.PubDate != "" {
-		t, err := time.Parse(time.RFC1123Z, aux.PubDate)
+		t, err := parseTime(aux.PubDate)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse published date %q: %w", aux.PubDate, err)
 		}
 		ch.PubDate = t
 	}
 	if aux.LastBuildDate != "" {
-		t, err := time.Parse(time.RFC1123Z, aux.LastBuildDate)
+		t, err := parseTime(aux.LastBuildDate)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse last build date %q: %w", aux.LastBuildDate, err)
 		}
 		ch.LastBuildDate = t
 	}
@@ -98,9 +99,9 @@ func (it *Item) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return err
 	}
 	if aux.PubDate != "" {
-		t, err := time.Parse(time.RFC1123Z, aux.PubDate)
+		t, err := parseTime(aux.PubDate)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse published date %q: %w", aux.PubDate, err)
 		}
 		it.PubDate = t
 	}
@@ -117,4 +118,20 @@ func Decode(r io.Reader) (*RSS, error) {
 		return nil, err
 	}
 	return &rss, nil
+}
+
+func parseTime(s string) (time.Time, error) {
+	layouts := []string{
+		time.RFC1123Z, time.RFC1123,
+		time.RFC822Z, time.RFC822,
+		"Mon, _2 Jan 2006 15:04:05 -0700",     // rfc1123z with no trailing zero
+		"Mon, _2 January 2006 15:04:05 -0700", // long month name
+	}
+	for _, l := range layouts {
+		t, err := time.Parse(l, s)
+		if err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unsupported layout")
 }

--- a/rss/rss.go
+++ b/rss/rss.go
@@ -7,6 +7,9 @@ import (
 	"time"
 )
 
+// MediaType is RSS' MIME media type.
+const MediaType = "application/rss+xml"
+
 type RSS struct {
 	Version string  `xml:"version,attr"`
 	Channel Channel `xml:"channel"`

--- a/rss/rss_test.go
+++ b/rss/rss_test.go
@@ -61,3 +61,20 @@ func TestEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestParseTime(t *testing.T) {
+	var tests = []struct {
+		name      string
+		timestamp string
+	}{
+		{"no leading zero", "Fri, 4 Feb 2022 09:30:00 +1300"}, // https://benhoyt.com/writings/rss.xml
+		{"long month", "Mon, 10 June 2024 12:20:00 +0000"},    // https://www.claws-mail.org/releases.rss
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseTime(tt.timestamp); err != nil {
+				t.Errorf("parse %q: %v", tt.timestamp, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I parsed every feed listed in opml/otl.opml and found a bunch of variants of RFC 822 and RFC 1123 timestamps used.